### PR TITLE
refactor: unify API naming to spawn_entity/despawn_entity for parity …

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -91,7 +91,7 @@ let mut world = World::new(registry.clone());
 world.current_mode = "colony".to_string();
 
 // Spawn an entity and set components
-let entity = world.spawn();
+let entity = world.spawn_entity();
 world.set_component(entity, "Health", serde_json::json!({"current": 10, "max": 10})).unwrap();
 ```
 

--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -22,8 +22,8 @@ world = PyWorld(schema_dir="/path/to/schemas")
 
 | Method                              | Description                             |
 | ----------------------------------- | --------------------------------------- |
-| `spawn()`                           | Spawn a new entity, returns entity ID   |
-| `despawn(entity_id)`                | Remove an entity and all its components |
+| `spawn_entity()`                           | Spawn a new entity, returns entity ID   |
+| `despawn_entity(entity_id)`                | Remove an entity and all its components |
 | `get_entities()`                    | List all entity IDs                     |
 | `get_entities_with_component(name)` | List entity IDs with a given component  |
 
@@ -83,7 +83,7 @@ from mge import PyWorld
 world = PyWorld("/path/to/schemas")
 
 # Spawn a player entity
-player = world.spawn()
+player = world.spawn_entity()
 world.set_component(player, "Type", {"kind": "player"})
 world.set_component(player, "Health", {"current": 10, "max": 10})
 

--- a/engine/core/src/scripting/world.rs
+++ b/engine/core/src/scripting/world.rs
@@ -24,7 +24,7 @@ impl World {
         }
     }
 
-    pub fn spawn(&mut self) -> u32 {
+    pub fn spawn_entity(&mut self) -> u32 {
         let id = self.next_id;
         self.next_id += 1;
         self.entities.push(id);

--- a/engine/core/tests/component_registry.rs
+++ b/engine/core/tests/component_registry.rs
@@ -165,7 +165,7 @@ fn test_schema_driven_mode_enforcement() {
     let registry = Arc::new(registry);
 
     let mut world = World::new(registry.clone());
-    let entity = world.spawn();
+    let entity = world.spawn_entity();
 
     // Not allowed in "colony"
     world.current_mode = "colony".to_string();
@@ -254,7 +254,7 @@ fn test_mode_enforcement_for_runtime_registered_schema() {
     let registry = Arc::new(registry);
 
     let mut world = World::new(registry.clone());
-    let id = world.spawn();
+    let id = world.spawn_entity();
 
     // Allowed in "colony"
     world.current_mode = "colony".to_string();

--- a/engine/core/tests/death_removal.rs
+++ b/engine/core/tests/death_removal.rs
@@ -17,7 +17,7 @@ fn test_death_replaces_health_with_corpse_and_decay() {
 
     world.current_mode = "colony".to_string();
 
-    let id = world.spawn();
+    let id = world.spawn_entity();
     world
         .set_component(id, "Health", json!({ "current": 1.0, "max": 10.0 }))
         .unwrap();
@@ -52,7 +52,7 @@ fn test_decay_removes_entity_after_time() {
 
     world.current_mode = "colony".to_string();
 
-    let id = world.spawn();
+    let id = world.spawn_entity();
     world.set_component(id, "Corpse", json!({})).unwrap();
     world
         .set_component(id, "Decay", json!({ "time_remaining": 2 }))

--- a/engine/core/tests/health_system.rs
+++ b/engine/core/tests/health_system.rs
@@ -20,8 +20,8 @@ fn test_damage_all_reduces_health() {
     let mut world = World::new(registry.clone());
     world.current_mode = "colony".to_string(); // Ensure correct mode
 
-    let id1 = world.spawn();
-    let id2 = world.spawn();
+    let id1 = world.spawn_entity();
+    let id2 = world.spawn_entity();
 
     world
         .set_component(id1, "Health", json!({ "current": 10.0, "max": 10.0 }))

--- a/engine/core/tests/mode_switching.rs
+++ b/engine/core/tests/mode_switching.rs
@@ -25,7 +25,7 @@ fn test_schema_driven_mode_enforcement() {
     let registry = Arc::new(registry);
 
     let mut world = World::new(registry.clone());
-    let entity = world.spawn();
+    let entity = world.spawn_entity();
 
     world.current_mode = "colony".to_string();
     let result = world.set_component(entity, "Inventory", json!({"slots": [], "weight": 0.0}));

--- a/engine/core/tests/movement_system.rs
+++ b/engine/core/tests/movement_system.rs
@@ -20,8 +20,8 @@ fn test_move_all_moves_positions() {
     let mut world = World::new(registry.clone());
     world.current_mode = "colony".to_string();
 
-    let id1 = world.spawn();
-    let id2 = world.spawn();
+    let id1 = world.spawn_entity();
+    let id2 = world.spawn_entity();
 
     // Set initial positions
     world

--- a/engine/core/tests/scripting.rs
+++ b/engine/core/tests/scripting.rs
@@ -178,8 +178,8 @@ fn test_get_entities_with_component() {
     let registry = setup_registry();
     let mut world = World::new(registry.clone());
     world.current_mode = "colony".to_string();
-    let id1 = world.spawn();
-    let id2 = world.spawn();
+    let id1 = world.spawn_entity();
+    let id2 = world.spawn_entity();
     world
         .set_component(id1, "Type", json!({ "kind": "player" }))
         .unwrap();
@@ -197,7 +197,7 @@ fn test_move_entity() {
     let registry = setup_registry();
     let mut world = World::new(registry.clone());
     world.current_mode = "colony".to_string();
-    let id = world.spawn();
+    let id = world.spawn_entity();
     world
         .set_component(id, "Position", json!({ "x": 0.0, "y": 0.0 }))
         .unwrap();
@@ -212,7 +212,7 @@ fn test_is_entity_alive() {
     let registry = setup_registry();
     let mut world = World::new(registry.clone());
     world.current_mode = "colony".to_string();
-    let id = world.spawn();
+    let id = world.spawn_entity();
     world
         .set_component(id, "Health", json!({ "current": 5.0, "max": 5.0 }))
         .unwrap();
@@ -228,7 +228,7 @@ fn test_damage_entity() {
     let registry = setup_registry();
     let mut world = World::new(registry.clone());
     world.current_mode = "colony".to_string();
-    let id = world.spawn();
+    let id = world.spawn_entity();
     world
         .set_component(id, "Health", json!({ "current": 10.0, "max": 10.0 }))
         .unwrap();
@@ -247,9 +247,9 @@ fn test_count_entities_with_type() {
     let registry = setup_registry();
     let mut world = World::new(registry.clone());
     world.current_mode = "colony".to_string();
-    let player = world.spawn();
-    let enemy1 = world.spawn();
-    let enemy2 = world.spawn();
+    let player = world.spawn_entity();
+    let enemy1 = world.spawn_entity();
+    let enemy2 = world.spawn_entity();
 
     world
         .set_component(player, "Type", json!({ "kind": "player" }))

--- a/engine/core/tests/turn_system.rs
+++ b/engine/core/tests/turn_system.rs
@@ -21,7 +21,7 @@ fn test_tick_advances_turn_and_runs_systems() {
     let mut world = World::new(registry.clone());
     world.current_mode = "colony".to_string();
 
-    let id = world.spawn();
+    let id = world.spawn_entity();
     world
         .set_component(id, "Position", serde_json::json!({ "x": 0.0, "y": 0.0 }))
         .unwrap();

--- a/engine/core/tests/type_component.rs
+++ b/engine/core/tests/type_component.rs
@@ -18,7 +18,7 @@ fn test_set_and_get_type_component() {
     let mut world = World::new(registry.clone());
     world.current_mode = "colony".to_string();
 
-    let id = world.spawn();
+    let id = world.spawn_entity();
     let type_value = json!({ "kind": "player" });
     world.set_component(id, "Type", type_value.clone()).unwrap();
 

--- a/engine_py/README.md
+++ b/engine_py/README.md
@@ -6,10 +6,10 @@ This document describes the Python API for interacting with the Modular Game Eng
 
 ### Entity Management
 
-- `spawn() -> int`
+- `spawn_entity() -> int`
   Spawn a new entity and return its ID.
 
-- `despawn(entity_id: int)`
+- `despawn_entity(entity_id: int)`
   Remove an entity and all its components.
 
 ### Component Management
@@ -76,7 +76,7 @@ from mge import PyWorld
 
 world = PyWorld()
 
-eid = world.spawn()
+eid = world.spawn_entity()
 world.set_component(eid, "Health", {"current": 10, "max": 10})
 
 print(world.get_component(eid, "Health"))

--- a/engine_py/src/lib.rs
+++ b/engine_py/src/lib.rs
@@ -45,13 +45,13 @@ impl PyWorld {
     }
 
     /// Spawn a new entity and return its ID.
-    fn spawn(&self) -> u32 {
+    fn spawn_entity(&self) -> u32 {
         let mut world = self.inner.lock().unwrap();
-        world.spawn()
+        world.spawn_entity()
     }
 
     /// Remove an entity and all its components.
-    fn despawn(&self, entity: u32) {
+    fn despawn_entity(&self, entity: u32) {
         let mut world = self.inner.lock().unwrap();
         world.remove_entity(entity);
         // Optionally, also remove from world.entities if not already done

--- a/engine_py/tests/test_basic.py
+++ b/engine_py/tests/test_basic.py
@@ -10,7 +10,7 @@ def test_spawn_and_set_component():
         os.path.join(here, "../../engine/assets/schemas")
     )
     world = mge.PyWorld(schema_dir)
-    eid = world.spawn()
+    eid = world.spawn_entity()
     world.set_component(eid, "Health", {"current": 10, "max": 10})
     comp = world.get_component(eid, "Health")
     print("Component:", comp)

--- a/engine_py/tests/test_entity_manage.py
+++ b/engine_py/tests/test_entity_manage.py
@@ -13,17 +13,17 @@ def make_world():
 
 def test_despawn_and_remove_component():
     world = make_world()
-    eid = world.spawn()
+    eid = world.spawn_entity()
     world.set_component(eid, "Health", {"current": 10, "max": 10})
     world.remove_component(eid, "Health")
     assert world.get_component(eid, "Health") is None
-    world.despawn(eid)
+    world.despawn_entity(eid)
     assert eid not in world.get_entities()
 
 
 def test_is_entity_alive():
     world = make_world()
-    eid = world.spawn()
+    eid = world.spawn_entity()
     world.set_component(eid, "Health", {"current": 10, "max": 10})
     assert world.is_entity_alive(eid)
     world.set_component(eid, "Health", {"current": 0, "max": 10})

--- a/engine_py/tests/test_entity_query.py
+++ b/engine_py/tests/test_entity_query.py
@@ -10,8 +10,8 @@ def test_get_entities_with_component():
     )
     world = mge.PyWorld(schema_dir)
 
-    eid1 = world.spawn()
-    eid2 = world.spawn()
+    eid1 = world.spawn_entity()
+    eid2 = world.spawn_entity()
 
     world.set_component(eid1, "Health", {"current": 5, "max": 10})
 
@@ -28,8 +28,8 @@ def test_get_entities():
     )
     world = mge.PyWorld(schema_dir)
 
-    eid1 = world.spawn()
-    eid2 = world.spawn()
+    eid1 = world.spawn_entity()
+    eid2 = world.spawn_entity()
 
     all_ids = world.get_entities()
 

--- a/engine_py/tests/test_systems.py
+++ b/engine_py/tests/test_systems.py
@@ -13,13 +13,13 @@ def make_world():
 
 def test_move_and_damage():
     world = make_world()
-    eid = world.spawn()
+    eid = world.spawn_entity()
     world.set_component(eid, "Position", {"x": 0, "y": 0})
     world.move_entity(eid, 2, 3)
     pos = world.get_component(eid, "Position")
     assert pos["x"] == 2 and pos["y"] == 3
 
-    eid2 = world.spawn()
+    eid2 = world.spawn_entity()
     world.set_component(eid2, "Position", {"x": 1, "y": 1})
     world.move_all(1, 1)
     pos1 = world.get_component(eid, "Position")
@@ -30,13 +30,13 @@ def test_move_and_damage():
 
 def test_damage_and_tick():
     world = make_world()
-    eid = world.spawn()
+    eid = world.spawn_entity()
     world.set_component(eid, "Health", {"current": 10, "max": 10})
     world.damage_entity(eid, 3)
     health = world.get_component(eid, "Health")
     assert health["current"] == 7
 
-    eid2 = world.spawn()
+    eid2 = world.spawn_entity()
     world.set_component(eid2, "Health", {"current": 5, "max": 5})
     world.damage_all(2)
     h1 = world.get_component(eid, "Health")
@@ -54,7 +54,7 @@ def test_tick_and_turn():
 
 def test_process_deaths_and_decay():
     world = make_world()
-    eid = world.spawn()
+    eid = world.spawn_entity()
     world.set_component(eid, "Health", {"current": 0, "max": 10})
     world.process_deaths()
     corpse = world.get_component(eid, "Corpse")
@@ -71,8 +71,8 @@ def test_process_deaths_and_decay():
 
 def test_count_entities_with_type():
     world = make_world()
-    e1 = world.spawn()
-    e2 = world.spawn()
+    e1 = world.spawn_entity()
+    e2 = world.spawn_entity()
     world.set_component(e1, "Type", {"kind": "player"})
     world.set_component(e2, "Type", {"kind": "enemy"})
     assert world.count_entities_with_type("player") == 1


### PR DESCRIPTION
…across Python and Lua