### PR TITLE
feat(schema-linter): initial schema validation implementation with tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,6 +818,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "schema_validator"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "schemars"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
 [workspace]
-members = ["engine/core", "engine_macros", "engine_py"]
+members = [
+  "engine/core",
+  "engine_macros",
+  "engine_py",
+  "engine/tools/schema_validator",
+]
 resolver = "3"

--- a/engine/tools/schema_validator/Cargo.toml
+++ b/engine/tools/schema_validator/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "schema_validator"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/engine/tools/schema_validator/src/lib.rs
+++ b/engine/tools/schema_validator/src/lib.rs
@@ -1,0 +1,45 @@
+use serde_json::Value;
+
+pub fn validate_schema(schema_json: &str) -> Result<(), String> {
+    let value: Value =
+        serde_json::from_str(schema_json).map_err(|e| format!("Invalid JSON: {e}"))?;
+
+    // 1. Check for "title"
+    if value.get("title").is_none() {
+        return Err("Missing required field 'title'".to_string());
+    }
+
+    // 2. Check for "modes"
+    let modes = match value.get("modes") {
+        Some(m) => m,
+        None => return Err("Missing required field 'modes'".to_string()),
+    };
+
+    // 3. Check that "modes" is an array of valid strings
+    let allowed_modes = ["colony", "roguelike", "single", "multi"];
+    if let Some(arr) = modes.as_array() {
+        for mode in arr {
+            let mode_str = mode.as_str().ok_or("Mode must be a string")?;
+            if !allowed_modes.contains(&mode_str) {
+                return Err(format!("Unknown mode '{}'", mode_str));
+            }
+        }
+    } else {
+        return Err("\"modes\" must be an array".to_string());
+    }
+
+    // 4. Check for min > max in properties
+    if let Some(props) = value.get("properties").and_then(|p| p.as_object()) {
+        for (prop_name, prop) in props {
+            if let Some(min) = prop.get("minimum").and_then(|v| v.as_f64()) {
+                if let Some(max) = prop.get("maximum").and_then(|v| v.as_f64()) {
+                    if min > max {
+                        return Err(format!("Property '{}' has minimum > maximum", prop_name));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/engine/tools/schema_validator/tests/validation_tests.rs
+++ b/engine/tools/schema_validator/tests/validation_tests.rs
@@ -1,0 +1,65 @@
+use schema_validator::validate_schema;
+
+#[test]
+fn test_missing_title_field() {
+    let schema_json = r#"
+    {
+        "type": "object",
+        "properties": {
+            "value": { "type": "number" }
+        },
+        "required": ["value"],
+        "modes": ["colony"]
+    }
+    "#;
+
+    let result = validate_schema(schema_json);
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .contains("Missing required field 'title'")
+    );
+}
+
+#[test]
+fn test_invalid_mode_name() {
+    let schema_json = r#"
+    {
+        "title": "Mana",
+        "type": "object",
+        "properties": {
+            "value": { "type": "number" }
+        },
+        "required": ["value"],
+        "modes": ["invalid_mode"]
+    }
+    "#;
+
+    let result = validate_schema(schema_json);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("Unknown mode 'invalid_mode'"));
+}
+
+#[test]
+fn test_min_greater_than_max() {
+    let schema_json = r#"
+    {
+        "title": "Health",
+        "type": "object",
+        "properties": {
+            "current": { "type": "number", "minimum": 100, "maximum": 50 }
+        },
+        "required": ["current"],
+        "modes": ["colony"]
+    }
+    "#;
+
+    let result = validate_schema(schema_json);
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .contains("Property 'current' has minimum > maximum")
+    );
+}


### PR DESCRIPTION
- Added schema_validator crate under engine/tools
- Implemented basic JSON schema validation:
  * Required "title" field
  * "modes" field validation against allowed modes
  * Property constraints check (minimum <= maximum)
- Added integration tests covering invalid schemas
- All tests passing and clippy clean