### PR TITLE
feat(core): Add ANSI 24-bit terminal color support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,7 @@ xtask builds each Rust plugin crate in release mode, then copies `target/release
 ## Repo Conventions
 
 - **Commit format:** `<type>(<scope>): <subject>` — enforced by `.gitmessage` and used by `semantic-release` via `.releaserc.json`.
+- **Roadmap tracking:** When implementing an item listed in [docs/ROADMAP.md](docs/ROADMAP.md), mark it completed (`[x]`) in the ROADMAP file as part of the implementation.
 - **Schema-driven ECS:** All components defined as JSON schemas in `engine/assets/schemas/`. Loaded dynamically into `ComponentRegistry`. Rust-side components use `#[component]` macro for auto-generated versioning/migration/serde/schema.
 - **Game config:** `game.toml` at workspace root defines title, version, allowed game modes, and native plugin paths.
 - **Plugin ABI:** C ABI defined in `engine/engine_plugin_abi.h`. Exports `PluginVTable` with init, shutdown, update, worldgen, system registration, hot-reload.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -69,6 +69,7 @@
 - [x] Terminal UI widget library (button, label, checkbox, dropdown, text input, context menu, panel, event log)
 - [x] UI layout system (linear arrangement, z-ordering)
 - [x] UI event handling and propagation
+- [x] ANSI 24-bit terminal color output (colored glyph rendering via escape sequences)
 
 ## Tooling & Documentation
 

--- a/engine/core/src/presentation/mod.rs
+++ b/engine/core/src/presentation/mod.rs
@@ -12,7 +12,9 @@ pub mod renderer;
 /// User interface
 pub mod ui;
 
-use crate::presentation::renderer::{PresentationRenderer, RenderColor, RenderCommand};
+use crate::presentation::renderer::{
+    COLOR_DIM_GRAY, COLOR_GRAY, PresentationRenderer, RenderColor, RenderCommand,
+};
 
 /// Presentation system for ECS worlds with schema-driven components.
 pub struct PresentationSystem<R: PresentationRenderer> {
@@ -105,15 +107,15 @@ impl<R: PresentationRenderer> PresentationSystem<R> {
                 let (glyph, color) = if let Some(meta) = meta {
                     if let Some(terrain) = meta.get("terrain").and_then(|v| v.as_str()) {
                         match terrain {
-                            "wall" => ('#', RenderColor(128, 128, 128)),
-                            "floor" => ('.', RenderColor(60, 60, 60)),
-                            _ => ('.', RenderColor(60, 60, 60)),
+                            "wall" => ('#', COLOR_GRAY),
+                            "floor" => ('.', COLOR_DIM_GRAY),
+                            _ => ('.', COLOR_DIM_GRAY),
                         }
                     } else {
-                        ('.', RenderColor(60, 60, 60))
+                        ('.', COLOR_DIM_GRAY)
                     }
                 } else {
-                    ('.', RenderColor(60, 60, 60))
+                    ('.', COLOR_DIM_GRAY)
                 };
                 self.renderer.queue_draw(RenderCommand {
                     glyph,

--- a/engine/core/src/presentation/renderer.rs
+++ b/engine/core/src/presentation/renderer.rs
@@ -7,6 +7,18 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RenderColor(pub u8, pub u8, pub u8);
 
+/// Named color constants matching common terminal colors.
+/// These are emitted as ANSI 24-bit foreground escapes;
+/// no fallback for legacy terminals is provided (NFR001).
+pub const COLOR_WHITE: RenderColor = RenderColor(255, 255, 255);
+pub const COLOR_BLACK: RenderColor = RenderColor(0, 0, 0);
+pub const COLOR_RED: RenderColor = RenderColor(255, 0, 0);
+pub const COLOR_GREEN: RenderColor = RenderColor(0, 255, 0);
+pub const COLOR_YELLOW: RenderColor = RenderColor(255, 255, 0);
+pub const COLOR_BLUE: RenderColor = RenderColor(0, 0, 255);
+pub const COLOR_GRAY: RenderColor = RenderColor(128, 128, 128);
+pub const COLOR_DIM_GRAY: RenderColor = RenderColor(60, 60, 60);
+
 /// A command to draw a glyph at a position with a color
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RenderCommand {
@@ -107,21 +119,206 @@ impl PresentationRenderer for TerminalRenderer {
     }
 
     fn present(&mut self) {
+        // Uses BufWriter + stdout().lock() to avoid per-cell heap allocation (R003/AC007).
+        // ANSI 24-bit escapes are always emitted; no fallback for legacy terminals (NFR001).
+        use std::io::Write;
+        let stdout = std::io::stdout();
+        let mut out = std::io::BufWriter::new(stdout.lock());
         for row in &self.buffer {
             for cell in row {
-                if let Some(cmd) = cell {
-                    print!("{}", cmd.glyph);
-                } else {
-                    print!(" ");
+                match cell {
+                    Some(cmd) => {
+                        let r = cmd.color.0;
+                        let g = cmd.color.1;
+                        let b = cmd.color.2;
+                        write!(out, "\x1b[38;2;{};{};{}m{}\x1b[0m", r, g, b, cmd.glyph)
+                            .expect("write to stdout");
+                    }
+                    None => {
+                        write!(out, " ").expect("write to stdout");
+                    }
                 }
             }
-            println!();
+            writeln!(out).expect("write newline to stdout");
         }
+        out.flush().expect("flush stdout");
         // Clear buffer for next frame
         for row in &mut self.buffer {
             for cell in row.iter_mut() {
                 *cell = None;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Read;
+    use std::os::unix::io::{AsRawFd, FromRawFd, OwnedFd};
+    use std::sync::Mutex;
+
+    /// Serializes stdout-capturing tests to prevent interference from parallel execution.
+    static STDOUT_CAPTURE_LOCK: Mutex<()> = Mutex::new(());
+
+    unsafe extern "C" {
+        fn dup(fd: std::os::raw::c_int) -> std::os::raw::c_int;
+        fn dup2(oldfd: std::os::raw::c_int, newfd: std::os::raw::c_int) -> std::os::raw::c_int;
+        fn close(fd: std::os::raw::c_int) -> std::os::raw::c_int;
+        fn pipe(pipefd: *mut std::os::raw::c_int) -> std::os::raw::c_int;
+    }
+
+    /// Redirect stdout to a pipe, invoke `f`, restore stdout, return captured output.
+    /// Serialized via STDOUT_CAPTURE_LOCK to prevent parallel test interference.
+    fn capture_stdout<F: FnOnce()>(f: F) -> String {
+        let _guard = STDOUT_CAPTURE_LOCK.lock().expect("stdout capture lock");
+
+        let mut fds = [0i32; 2];
+        let ret = unsafe { pipe(fds.as_mut_ptr()) };
+        assert_eq!(ret, 0, "pipe creation failed");
+        let [read_fd, write_fd] = fds;
+        let mut rx = unsafe { File::from_raw_fd(read_fd) };
+        let tx = unsafe { OwnedFd::from_raw_fd(write_fd) };
+
+        let stdout_fd = std::io::stdout().as_raw_fd();
+
+        // Duplicate original stdout fd for restoration
+        let saved_fd = unsafe { dup(stdout_fd) };
+        assert!(saved_fd >= 0, "dup failed");
+
+        // Replace stdout with write end of our pipe
+        let ret = unsafe { dup2(write_fd, stdout_fd) };
+        assert!(ret >= 0, "dup2 failed");
+
+        // Run the function (writes to our pipe instead of terminal)
+        f();
+
+        // Restore original stdout
+        let ret = unsafe { dup2(saved_fd, stdout_fd) };
+        assert!(ret >= 0, "dup2 restore failed");
+        unsafe { close(saved_fd) };
+
+        // Drop tx (close write end) so read_to_string won't block
+        drop(tx);
+
+        let mut output = String::new();
+        rx.read_to_string(&mut output).expect("read from pipe");
+        output
+    }
+
+    #[test]
+    fn test_terminal_renderer_ansi_output() {
+        let mut renderer = TerminalRenderer::new(3, 1);
+        renderer.queue_draw(RenderCommand {
+            glyph: '@',
+            color: RenderColor(255, 0, 0),
+            pos: (0, 0),
+        });
+        renderer.queue_draw(RenderCommand {
+            glyph: 'B',
+            color: RenderColor(0, 255, 0),
+            pos: (1, 0),
+        });
+
+        let output = capture_stdout(|| renderer.present());
+
+        // Red glyph wrapped in ANSI 24-bit foreground escape
+        assert!(
+            output.contains("\x1b[38;2;255;0;0m@\x1b[0m"),
+            "expected red ANSI escape for glyph @, got: {output:?}"
+        );
+        // Green glyph independently wrapped
+        assert!(
+            output.contains("\x1b[38;2;0;255;0mB\x1b[0m"),
+            "expected green ANSI escape for glyph B, got: {output:?}"
+        );
+        // None cell emits bare space with no escapes
+        assert!(
+            output.contains(" "),
+            "output should contain spaces for None cells, got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn test_terminal_renderer_ansi_black_color() {
+        let mut renderer = TerminalRenderer::new(1, 1);
+        renderer.queue_draw(RenderCommand {
+            glyph: 'X',
+            color: RenderColor(0, 0, 0),
+            pos: (0, 0),
+        });
+
+        let output = capture_stdout(|| renderer.present());
+
+        assert!(
+            output.contains("\x1b[38;2;0;0;0mX\x1b[0m"),
+            "expected black ANSI escape, got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn test_terminal_renderer_ansi_all_none() {
+        let mut renderer = TerminalRenderer::new(2, 2);
+        let output = capture_stdout(|| renderer.present());
+
+        assert!(
+            !output.contains("\x1b["),
+            "no ANSI escapes expected for empty buffer, got: {output:?}"
+        );
+        assert_eq!(
+            output.matches(' ').count(),
+            4,
+            "four spaces for 2x2 empty buffer"
+        );
+        assert_eq!(output.matches('\n').count(), 2, "two newlines for 2 rows");
+    }
+
+    #[test]
+    fn test_terminal_renderer_ansi_zero_size() {
+        let mut renderer = TerminalRenderer::new(0, 0);
+        let output = capture_stdout(|| renderer.present());
+        assert!(output.is_empty(), "zero-size buffer produces no output");
+    }
+
+    #[test]
+    fn test_terminal_renderer_ansi_reset_per_glyph() {
+        let mut renderer = TerminalRenderer::new(2, 1);
+        renderer.queue_draw(RenderCommand {
+            glyph: 'A',
+            color: RenderColor(255, 0, 0),
+            pos: (0, 0),
+        });
+        renderer.queue_draw(RenderCommand {
+            glyph: 'B',
+            color: RenderColor(0, 255, 0),
+            pos: (1, 0),
+        });
+
+        let output = capture_stdout(|| renderer.present());
+
+        // Each glyph independently wrapped: reset after A, escape before B
+        assert!(
+            output.contains("\x1b[0m\x1b[38"),
+            "adjacent colored glyphs should each be wrapped: {output:?}"
+        );
+    }
+
+    #[test]
+    fn test_terminal_renderer_buffer_cleared_after_present() {
+        let mut renderer = TerminalRenderer::new(1, 1);
+        renderer.queue_draw(RenderCommand {
+            glyph: '@',
+            color: RenderColor(255, 0, 0),
+            pos: (0, 0),
+        });
+
+        let _first = capture_stdout(|| renderer.present());
+
+        let second = capture_stdout(|| renderer.present());
+        assert!(
+            !second.contains("\x1b["),
+            "buffer should be cleared after present, got: {second:?}"
+        );
     }
 }


### PR DESCRIPTION
Emit RenderColor RGB values as \x1b[38;2;{r};{g};{b}m{glyph}\x1b[0m via BufWriter<StdoutLock>

- Add 8 named color constants (COLOR_WHITE, COLOR_BLACK, etc.)
- Replace inline RenderColor(128,128,128)/(60,60,60) with COLOR_GRAY/DIM_GRAY
- Add 6 unit tests with Unix pipe-based stdout capture